### PR TITLE
use strict and warnings

### DIFF
--- a/lib/Swim/Plugin/badge.pm
+++ b/lib/Swim/Plugin/badge.pm
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 package Swim::Plugin::badge;
 our $VERSION = '0.1.8';
 


### PR DESCRIPTION
I've been assigned this dist for the [CPAN PR Challenge](http://cpan-prc.org/) for July - thanks for participating.

There are a few outstanding [Issues at CPANTS](https://cpants.cpanauthors.org/release/INGY/Swim-Plugin-badge-0.1.8) and this PR addresses 2 of those: strict and warnings. I've added them into the dist and the tests run cleanly for me. If there's some reason not to use strict and warnings here, please let me know.

Likewise, if there's anything in particular with this dist which you think could use some attention I'd be keen to hear about that too.